### PR TITLE
Added support for 6.3.9600.19318

### DIFF
--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -631,6 +631,32 @@ SLInitHook.x64=1
 SLInitOffset.x64=5D660
 SLInitFunc.x64=New_CSLQuery_Initialize
 
+[6.3.9600.19318]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=B43E8
+LocalOnlyCode.x86=jmpshort
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=89EAC
+LocalOnlyCode.x64=nopjmp
+SingleUserPatch.x86=1
+SingleUserOffset.x86=3ED25
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=35779
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=3D579
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=43CE5
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x86=1
+SLInitOffset.x86=180F8
+SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=5C0D0
+SLInitFunc.x64=New_CSLQuery_Initialize
+
 [6.4.9841.0]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=956A8
@@ -3307,6 +3333,25 @@ bMultimonAllowed.x86  =D3078
 bServerSku.x86        =D307C
 ulMaxDebugSessions.x86=D3080
 bRemoteConnAllowed.x86=D3084
+
+bFUSEnabled.x64       =FA054
+lMaxUserSessions.x64  =FA058
+bAppServerAllowed.x64 =FA05C
+bInitialized.x64      =FA060
+bMultimonAllowed.x64  =FA064
+bServerSku.x64        =FA068
+ulMaxDebugSessions.x64=FA06C
+bRemoteConnAllowed.x64=FA070
+
+[6.3.9600.19318-SLInit]
+bFUSEnabled.x86       =D4068
+lMaxUserSessions.x86  =D406C
+bAppServerAllowed.x86 =D4070
+bInitialized.x86      =D4074
+bMultimonAllowed.x86  =D4078
+bServerSku.x86        =D407C
+ulMaxDebugSessions.x86=D4080
+bRemoteConnAllowed.x86=D4084
 
 bFUSEnabled.x64       =FA054
 lMaxUserSessions.x64  =FA058


### PR DESCRIPTION
6.3.9600.19318 is termsrv.dll for Windows 8.1 Pro

Well please also Update the date in:
[Main]
Updated=

Since I forgot that on this Pull request